### PR TITLE
Added tracking token expiration

### DIFF
--- a/custom_components/airthings_cloud/sensor.py
+++ b/custom_components/airthings_cloud/sensor.py
@@ -3,6 +3,7 @@ import asyncio
 import datetime
 import json
 import logging
+import time
 
 import aiohttp
 import async_timeout
@@ -125,6 +126,7 @@ class AirthingsData:
         self._session = session
 
         self.access_token = None
+        self.access_token_expiration = None
 
         self._timeout = 10
         self._updated_at = datetime.datetime.utcnow()
@@ -213,6 +215,7 @@ class AirthingsData:
                 return False
             result = await resp.json()
             self.access_token = result["access_token"]
+            self.access_token_expiration = time.time() + int(result["expires_in"])
 
         except aiohttp.ClientError as err:
             _LOGGER.error("Error connecting to Airthings: %s ", err, exc_info=True)
@@ -222,7 +225,7 @@ class AirthingsData:
         return True
 
     async def update_data(self):
-        if self.access_token is None:
+        if self.access_token is None or time.time() >= (self.access_token_expiration-60):
             await self.get_user_credentials()
 
         headers = {


### PR DESCRIPTION
This is to address the issue with becoming unauthorized every ~3 hours as noted in #14.  The line where the token, minus 60 seconds, is used to compare to the current time is rather arbitrary.  I am simply trying to add a buffer value so that we do not end up in a situation where the token is about to expire. I am certainly open to better alternatives.