### PR TITLE
Updating mapping for new multi dashboard

### DIFF
--- a/custom_components/airthings_cloud/sensor.py
+++ b/custom_components/airthings_cloud/sensor.py
@@ -240,7 +240,7 @@ class AirthingsData:
         try:
             with async_timeout.timeout(self._timeout):
                 resp = await self._session.get(
-                    "https://web-api.airthin.gs/v1/dashboard",
+                    "https://web-api.airthin.gs/v1/dashboards",
                     headers=headers,
                 )
             if resp.status != 200:
@@ -257,7 +257,7 @@ class AirthingsData:
         except asyncio.TimeoutError:
             return False
 
-        for device in result.get("tiles", []):
+        for device in result.get("currentDashboard", {}).get("tiles", []):
             device_id = device.get("content", {}).get("serialNumber")
             sensors = device.get("content", {}).get("currentSensorValues", [])
             if not sensors:


### PR DESCRIPTION
URL and mappings have changed for the Dashboard.

New URL is `https://web-api.airthin.gs/v1/dashboards` note the additional `s`
![image](https://user-images.githubusercontent.com/1595448/122498606-6aa68a80-cfbd-11eb-909f-e4fe39d72716.png)

The returned JSON has also changed and requires an additional nesting within `currentDashboard`

```
{
  "dashboards":[
    {
      "name":"Personal",
      "id":"foo",
      "visibility":"user"
    }
  ],
  "currentDashboard":{
    "name":"Personal",
    "id":"bar",
    "visibility":"user",
    "tiles":[
      {
        "id":"baz",
        "type":"device",
        "width":1,
        "ref":"quz",
        "content":{
          "serialNumber":"quz",
          "locationName":"Home",
          "roomName":"Living Room",
          "segmentStart":"2020-12-02T03:26:05",
          "latestSample":"2021-06-18T02:27:26",
          "currentSensorValues":[
            {
              "type":"radonShortTermAvg",
              "value":175.0,
              "providedUnit":"bq",
              "preferredUnit":"bq",
              "isAlert":true,
              "thresholds":[
                100,
                150
              ]
            },
```

I have this branch working on my Home Assistant

![image](https://user-images.githubusercontent.com/1595448/122498828-cbce5e00-cfbd-11eb-8b4c-89f2cc3bfcbc.png)

Addresses issue https://github.com/Danielhiversen/home_assistant_airthings_cloud/issues/26