### PR TITLE
Updated version and added iot_class to manifest.json to pass hassfest validation

### DIFF
--- a/custom_components/airthings_cloud/manifest.json
+++ b/custom_components/airthings_cloud/manifest.json
@@ -4,6 +4,7 @@
   "documentation": "https://github.com/Danielhiversen/home_assistant_airthings_cloud",
   "requirements": [],
   "issue_tracker": "https://github.com/Danielhiversen/home_assistant_airthings_cloud/issues",
-  "version": "0.1.4",
-  "codeowners": ["@danielhiversen"]
+  "version": "0.2.1",
+  "codeowners": ["@danielhiversen"],
+  "iot_class": "cloud_polling"
 }

--- a/custom_components/airthings_cloud/sensor.py
+++ b/custom_components/airthings_cloud/sensor.py
@@ -47,6 +47,8 @@ SENSOR_TYPES = {
     "co2": [CONCENTRATION_PARTS_PER_MILLION, None],
     "voc": [CONCENTRATION_PARTS_PER_BILLION, None],
     "battery": [PERCENTAGE, DEVICE_CLASS_BATTERY],
+    "pm1": ["µg/m³", None],
+    "pm25": ["µg/m³", None],
 }
 
 


### PR DESCRIPTION
Updated version to 0.2.1 in manifest.json in this commit.  Was still 0.1.4.  When you merge can you please create release 0.2.1?  That way a person can install 0.2.1 with HACS.  Right now the latest a person can install is 0.2.0 which does not include the new PM sensors for the View Plus.